### PR TITLE
Remove `arch` parameter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The `flux_install` data source generates a multi-doc YAML with Kubernetes manife
 # Generate manifests
 data "flux_install" "main" {
   target_path    = "production"
-  arch           = "amd64"
   network_policy = false
   version        = "latest"
 }


### PR DESCRIPTION
Hey there, thank you for this project! I am currently playing around with the GitOps Toolkit and have just noticed that the `arch` parameter has been removed from the `flux_install` resource in version `0.0.10` but was still present in the README. This PR simply removes this parameter from the README too.